### PR TITLE
Escape the double-quote rather than change it to a single quote.

### DIFF
--- a/src/custom_parser/__init__.py
+++ b/src/custom_parser/__init__.py
@@ -5,7 +5,7 @@ import ast
 import json
 
 def do_fastcore_decode(obj):
-    to_str_replace = str(obj).replace("\'", "\"")
+    to_str_replace = str(obj).replace("\"", "\\\"")
     valid_dict = ast.literal_eval(to_str_replace)
     return json.dumps(valid_dict)
 


### PR DESCRIPTION
If a pull request title or commit message contains a double quote, the decode function will fail as the json is invalid. Escape the double quotes rather than changing the single quotes to double quotes.