### PR TITLE
Make parent trace names consistent between runs

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -80,7 +80,7 @@ if len(job_lst) == 0:
 workflow_run_atts = json.loads(get_workflow_run_by_run_id)
 atts=parse_attributes(workflow_run_atts,"","workflow")
 print("Processing Workflow ->",GHA_RUN_NAME,"run id ->",GHA_RUN_ID)
-p_parent = tracer.start_span(name=str(GHA_RUN_NAME) + " - run: "+str(GHA_RUN_ID),attributes=atts,start_time=do_time(workflow_run_atts['run_started_at']),kind=trace.SpanKind.SERVER)
+p_parent = tracer.start_span(name=str(GHA_RUN_NAME),attributes=atts,start_time=do_time(workflow_run_atts['run_started_at']),kind=trace.SpanKind.SERVER)
 
 # Download logs
 # Have to use python requests due to known issue with ghapi -> https://github.com/fastai/ghapi/issues/119


### PR DESCRIPTION
With tracing in newrelic, groups are done via the name on the parent trace. With each run having a unique name (due to the run ID being unique each time), it makes it hard to use the traces and compare runs over time. If the previous functionality is desired by consumers of this action, it is easy enough to restore by updating the GHA_RUN_NAME environment variable, which is only used in the context of the name of the parent trace.

![Screenshot 2024-07-09 at 9 38 52 PM](https://github.com/newrelic-experimental/gha-new-relic-exporter/assets/1282393/ded0426f-464d-420b-b860-3ab5654f41b3)

The top group of traces were collected by github.com/inception-health/otel-export-trace-action and feature very similar results. This change is necessary for us to replace that action with this one. (note the difference in the service name, which this action achieves better by naming it after the repo)