### PR TITLE
Adjust docker base to prevent 429 issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM public.ecr.aws/docker/library/python:3.10-slim-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
Adjusts docker image base to a public ecr equivalent to avoid authentication issues when pulling.

In addition, this also upgrades from debian buster to debian bookworm as the OS base, which should work fine, but will need testing to verify.