### PR TITLE
Fix log retrieval for sub-workflows

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -136,7 +136,7 @@ for job in job_lst:
                 with trace.use_span(child_1, end_on_exit=False):
                     # Parse logs
                     try:
-                        with open ("./logs/"+str(job["name"])+"/"+str(step['number'])+"_"+str(step['name'].replace("/",""))+".txt") as f:
+                        with open ("./logs/"+str(job["name"]).replace("/", "")+"/"+str(step['number'])+"_"+str(step['name'].replace("/",""))+".txt") as f:
                             for line in f.readlines():
                                 try:
                                     line_to_add = line[29:-1].strip()
@@ -172,7 +172,7 @@ for job in job_lst:
                             print("Log file not expected for this step ->",step['name'],"<- because its status is ->",step['conclusion'])
                             pass #We don't expect log file to exist
                         else:
-                            print("ERROR: Log file does not exist: "+str(job["name"])+"/"+str(step['number'])+"_"+str(step['name'].replace("/",""))+".txt")
+                            print("ERROR: Log file does not exist: "+str(job["name"]).replace("/", "")+"/"+str(step['number'])+"_"+str(step['name'].replace("/",""))+".txt")
                             
 
                 if step['conclusion'] == 'skipped' or step['conclusion'] == 'cancelled':


### PR DESCRIPTION
## Description

For workflows using sub-workflows, the sub-workflow's job name will be prefixed with the parent workflow's job name that triggers it.

## Example

In this example, the workflow `Deploy to SIT` has a job called `Deploy SIT` that uses another workflow, which contains the job `Set roles`. Github will then name the job `Deploy SIT / Set roles`. The logs for this kind of workflow run will fail to be retrieved as the logs created strips the `/` from the job name.

![CleanShot 2024-08-22 at 10 09 43@2x](https://github.com/user-attachments/assets/8adba24f-0631-4350-a795-9b74027b0fd0)

Log created:

![CleanShot 2024-08-22 at 10 09 34@2x](https://github.com/user-attachments/assets/f4bf53f6-a92b-43bd-99ca-78f7cbb92061)


Retrieved log file location [incorrect]: `Deploy SIT / Set Roles/1_Set up job.txt`
Actual log file location: `Deploy SIT  Set Roles/1_Set up job.txt`
