### PR TITLE
Fix: Preserve angle brackets in job names for log file paths

### DIFF
--- a/src/custom_parser/__init__.py
+++ b/src/custom_parser/__init__.py
@@ -11,7 +11,8 @@ def sanitize_filename(name: str) -> str:
     # Normalize spaces around slashes, then replace '/' with ' _ '
     name = re.sub(r"\s*/\s*", "/", name)
     name = name.replace("/", " _ ")
-    name = re.sub(r'[\\:*?"<>|]', "_", name)
+    # Replace problematic characters but NOT < and > since GitHub Actions preserves them
+    name = re.sub(r'[\\:*?"|]', "_", name)
     name = name.strip()
     return name
 

--- a/tests/test_sanitize_filename.py
+++ b/tests/test_sanitize_filename.py
@@ -2,7 +2,7 @@ import unittest
 import sys
 
 sys.path.insert(0, "../src")
-from src.custom_parser.filename_utils import sanitize_filename
+from src.custom_parser import sanitize_filename
 
 
 class TestSanitizeFilename(unittest.TestCase):
@@ -22,7 +22,8 @@ class TestSanitizeFilename(unittest.TestCase):
             "job_name_with_special_chars",
         )
         self.assertEqual(sanitize_filename("job\\name"), "job_name")
-        self.assertEqual(sanitize_filename("job<name>"), "job_name_")
+        # < and > are now preserved since GitHub Actions preserves them in log folder names
+        self.assertEqual(sanitize_filename("job<name>"), "job<name>")
         self.assertEqual(sanitize_filename('job"name'), "job_name")
 
     def test_unicode(self):
@@ -31,6 +32,18 @@ class TestSanitizeFilename(unittest.TestCase):
 
     def test_strip(self):
         self.assertEqual(sanitize_filename("  job name  "), "job name")
+
+    def test_github_actions_folder_names(self):
+        # Test the exact case from the bug report
+        self.assertEqual(
+            sanitize_filename("Clone PROD > DEV branch"),
+            "Clone PROD > DEV branch",
+        )
+        # Test other common GitHub Actions naming patterns
+        self.assertEqual(
+            sanitize_filename("Build > Test > Deploy"),
+            "Build > Test > Deploy",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Modified sanitize_filename() to preserve < and > characters
- GitHub Actions preserves these characters in log folder names
- Fixes 'Log file does not exist' errors for jobs with names like 'Clone PROD > DEV branch'
- Updated tests to reflect new behavior and added specific test case