### PR TITLE
Upgrade Python to 3.12 and pin fastcore dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-opentelemetry.api
-opentelemetry.sdk
-opentelemetry.exporter.otlp.proto.grpc
-opentelemetry.instrumentation.logging
+ghapi>=1.0
+fastcore!=1.12.2
+opentelemetry-api>=1.0
+opentelemetry-sdk>=1.0
+opentelemetry-exporter-otlp-proto-grpc>=0.40b0
+opentelemetry-instrumentation-logging>=0.40b0
 pyrfc3339
-ghapi
 requests
 python-dateutil
 


### PR DESCRIPTION
## Summary
This PR addresses the fastcore version compatibility issue by upgrading the Python runtime to 3.12 and pinning dependency versions.

- Upgrades base Docker image from Python 3.10 to 3.12 (slim-bookworm)
- Excludes fastcore 1.12.2 which has a known f-string syntax error in Python 3.10
- Updates OpenTelemetry package names to correct PyPI naming (hyphen notation)
- Adds version constraints for improved reproducibility

## Resolves
Fixes SyntaxError from fastcore 1.12.2: f-string expression part cannot include a backslash
- Ref: AnswerDotAI/fastcore#751
- Python 3.12 is also more future-proof (3.10 reaches EOL in Oct 2026)

## Changes
- `Dockerfile`: `python:3.10-slim-buster` → `python:3.12-slim-bookworm`
- `requirements.txt`: Added fastcore!=1.12.2 and updated package names

## Testing
This PR should be tested by:
- Building the Docker image with `docker build -t gha-new-relic-exporter .`
- Verifying the exporter runs without the SyntaxError