### PR TITLE
fix(exporter): keep GitHub API operations synchronous

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,4 +1,3 @@
-from ghapi.all import GhApi
 from custom_parser import (
     do_time,
     do_fastcore_decode,
@@ -8,6 +7,7 @@ from custom_parser import (
     find_log_file,
     find_system_log_file,
 )
+from github_api import create_github_api_client
 import json
 import logging
 import os
@@ -72,10 +72,10 @@ endpoint = "{}".format(OTEL_EXPORTER_OTEL_ENDPOINT)
 headers = "api-key={}".format(NEW_RELIC_LICENSE_KEY)
 
 # Github API client
-api = GhApi(
+api = create_github_api_client(
     owner=GITHUB_REPOSITORY_OWNER,
     repo=GHA_SERVICE_NAME.split("/")[1],
-    token=str(GHA_TOKEN),
+    token=GHA_TOKEN,
 )
 
 # Github API calls

--- a/src/github_api.py
+++ b/src/github_api.py
@@ -1,0 +1,5 @@
+from ghapi.all import GhApi
+
+
+def create_github_api_client(owner, repo, token):
+    return GhApi(owner=owner, repo=repo, token=str(token), sync=True)

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,0 +1,33 @@
+import inspect
+import unittest
+from unittest.mock import patch
+
+from src.github_api import create_github_api_client
+
+
+class TestCreateGithubApiClient(unittest.TestCase):
+    @patch("src.github_api.GhApi")
+    def test_uses_synchronous_operations(self, gh_api):
+        create_github_api_client(owner="example", repo="repository", token="token")
+
+        gh_api.assert_called_once_with(
+            owner="example",
+            repo="repository",
+            token="token",
+            sync=True,
+        )
+
+    def test_operations_are_synchronous(self):
+        api = create_github_api_client(
+            owner="example",
+            repo="repository",
+            token="token",
+        )
+
+        self.assertFalse(
+            inspect.iscoroutinefunction(api.actions.get_workflow_run.__call__)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

[v1.0.9](https://github.com/newrelic-experimental/gha-new-relic-exporter/commit/32b41c4c462ddc29dfff39722f364e1e931ea6b9) upgraded `ghapi` from 1.0.10 to 2.1.3. `GhApi` 2.x defaults to asynchronous operations, while the exporter invokes those operations synchronously and immediately serializes their return values. The result is a coroutine passed to `json.dumps`:

```text
TypeError: Object of type coroutine is not JSON serializable
RuntimeWarning: coroutine 'OpFunc.__call__' was never awaited
```

## Change

Construct the GitHub API client with `sync=True`, matching the exporter's existing synchronous execution model and restoring workflow/job metadata retrieval.

This does not change telemetry selection: consumers using `GHA_EXPORT_LOGS=false` continue to export workflow, job, and step spans without emitting raw CI log records.