### PR TITLE
fix: set span status from GitHub's own conclusion instead of log grep

### DIFF
--- a/src/custom_parser/__init__.py
+++ b/src/custom_parser/__init__.py
@@ -5,6 +5,28 @@ import json
 from fastcore.xtras import obj2dict
 import re
 from pathlib import Path
+from opentelemetry.trace import Status, StatusCode
+
+# Conclusions that represent a failed GitHub Actions run, job, or step, mirroring
+# the OpenTelemetry recording-errors semantic conventions.
+# https://opentelemetry.io/docs/specs/semconv/general/recording-errors/
+ERROR_CONCLUSIONS = {"failure", "timed_out", "startup_failure"}
+
+
+def record_conclusion(span, conclusion):
+    """
+    Set `span`'s status to ERROR (with an `error.type` attribute) when
+    `conclusion` is a failed GitHub Actions conclusion. Leaves the status unset
+    otherwise, per the OpenTelemetry recording-errors conventions.
+
+    This is the only source of a workflow run's own span status: the run's
+    root span carries no logs to parse for "##[error]" lines, and a job's or
+    step's status should not depend on whether its log file happens to still be
+    available.
+    """
+    if conclusion in ERROR_CONCLUSIONS:
+        span.set_status(Status(StatusCode.ERROR, conclusion))
+        span.set_attribute("error.type", conclusion)
 
 
 def sanitize_filename(name: str) -> str:

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -6,6 +6,7 @@ from custom_parser import (
     sanitize_filename,
     find_log_file,
     find_system_log_file,
+    record_conclusion,
 )
 from github_api import create_github_api_client
 import json
@@ -139,6 +140,7 @@ p_parent = tracer.start_span(
     start_time=do_time(workflow_run_atts["run_started_at"]),
     kind=trace.SpanKind.SERVER,
 )
+record_conclusion(p_parent, workflow_run_atts.get("conclusion"))
 
 # Download logs
 # Have to use python requests due to known issue with ghapi -> https://github.com/fastai/ghapi/issues/119
@@ -224,6 +226,7 @@ for job in job_lst:
                 parse_attributes(job, "steps", "job"), GHA_SERVICE_NAME
             )
         )
+        record_conclusion(child_0, job.get("conclusion"))
         p_sub_context = trace.set_span_in_context(child_0)
 
         # Steps trace span
@@ -278,6 +281,7 @@ for job in job_lst:
                         parse_attributes(step, "", "job"), GHA_SERVICE_NAME
                     )
                 )
+                record_conclusion(child_1, step.get("conclusion"))
                 with trace.use_span(child_1, end_on_exit=False):
                     # Parse logs
                     log_path = find_log_file("./logs", job["name"], step["number"], step["name"])

--- a/tests/test_record_conclusion.py
+++ b/tests/test_record_conclusion.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import Mock
+
+from opentelemetry.trace import StatusCode
+
+from src.custom_parser import record_conclusion
+
+
+class TestRecordConclusion(unittest.TestCase):
+    def test_failed_conclusions_set_error_status(self):
+        for conclusion in ("failure", "timed_out", "startup_failure"):
+            span = Mock()
+            record_conclusion(span, conclusion)
+
+            span.set_status.assert_called_once()
+            status = span.set_status.call_args[0][0]
+            self.assertEqual(status.status_code, StatusCode.ERROR)
+            span.set_attribute.assert_called_once_with("error.type", conclusion)
+
+    def test_non_failed_conclusions_leave_status_unset(self):
+        for conclusion in ("success", "cancelled", "skipped", "neutral", "action_required", None):
+            span = Mock()
+            record_conclusion(span, conclusion)
+
+            span.set_status.assert_not_called()
+            span.set_attribute.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The exporter's only source of `ERROR` span status today is grepping step logs for `##[error]` lines, inside the per-step log-read loop. That leaves status dependent on data GitHub doesn't always provide (recycled logs due to retention) and misses the run's own span entirely.

**The run's root span (`p_parent`) is never passed to `set_status` at all.** There are no logs to parse for the run itself, so a failed run — GitHub's own `conclusion: "failure"` on the run object — produces a root span indistinguishable from a successful one. Measured against a real New Relic account: `otel.status_code` is null on the root span of a run GitHub reports as `failure`, and the error machinery derived from status (`TransactionError`, `apm.service.error.count`, `newrelic.goldenmetrics.ext.service.errorRate`) sees nothing for the service as a result.

**Job and step status depends on the log archive still being unconsolidated.** GitHub's log archive collapses per-step files (`<job>/<step_number>_<step_name>.txt`) into a single per-job file after some time. Exporting a run right after completion finds every step file; the same run exported later logs `ERROR: Log file does not exist` for every step and sets no status at all — even though `job["conclusion"]` and `step["conclusion"]` were already in the API response the whole time.